### PR TITLE
Parser changes

### DIFF
--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -10,6 +10,7 @@ use PulseAudio::Types qw();
 use autodie;
 use IPC::Run3;
 
+use Data::Dumper;
 our $_command_db;
 
 foreach my $name ( qw/card source source_output sink sink_input module client/ ) {
@@ -232,16 +233,9 @@ has 'info' => (
 		my %db;
 		while ( my $line = $fh->getline ) {
 
-		next if $line =~ /(?:
-			Speakers
-			| Headphones
-			| Internal Microphone
-			| Dock Microphone
-			| Microphone
-			| Speakers
-			| (?-x:HDMI \/ DisplayPort(?-x: \d)?)
-		) \s \(priority
-		/x;
+		        # a little information lost in "ports:" section
+		        next if $line =~ /device\.icon_name/;
+
 			chomp $line;
 			state ( $idx, $cat, $last_key );
 			state @tree_pos;
@@ -278,10 +272,7 @@ has 'info' => (
 					}
 					else {
 						my $x = \%{ $db{$cat}{$idx} };
-						my $level = 0;
-						while ( $level + 1 < @tree_pos ) {
-							$x = \%{ $x->{ $tree_pos[$level++]->{key} } };
-						}
+					        $x = \%{ $x->{ $tree_pos[0]->{key} } };
 						$x->{$k} = $v;
 					}
 					$last_key = $k;

--- a/t/12-parse.t
+++ b/t/12-parse.t
@@ -1,0 +1,6 @@
+use PulseAudio;
+use Test::More tests => 1;
+
+new_ok ( PulseAudio );
+
+1;


### PR DESCRIPTION
The current version of PulseAudio did not work for me as parser failed:

Use of uninitialized value in hash element at /usr/local/lib64/perl5/5.20.2/PulseAudio/Backend/Utilities.pm line 283, <$_[...]> line 342.
Use of uninitialized value in hash element at /usr/local/lib64/perl5/5.20.2/PulseAudio/Backend/Utilities.pm line 283, <$_[...]> line 345.
Use of uninitialized value in hash element at /usr/local/lib64/perl5/5.20.2/PulseAudio/Backend/Utilities.pm line 283, <$_[...]> line 438.
Use of uninitialized value in hash element at /usr/local/lib64/perl5/5.20.2/PulseAudio/Backend/Utilities.pm line 283, <$_[...]> line 441.
Can't use string ("Line Out (priority 9900, latency"...) as a HASH ref while "strict refs" in use at /usr/local/lib64/perl5/5.20.2/PulseAudio/Backend/Utilities.pm line 283, <$_[...]> line 450.

I am running PulseAudio 6.0 and this version appears to get things working.  It does not parse 100% of "pacmd info" output but more is parsed than with current version.  I did not check for backwards compatibility.  I am open to any suggestions for making this better.
