### PR TITLE
Module name fix and handling missing sections in info structure

### DIFF
--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -13,15 +13,13 @@ use IPC::Run3;
 our $_command_db;
 
 foreach my $name ( qw/card source source_output sink sink_input module client/ ) {
-    my $attr = $name . 's';
-    my @parts = split(/_/, $name);
-    foreach (@parts) { $_ = ucfirst; };
-    my $module = 'PulseAudio::' . join('', @parts );
+	my $attr = $name . 's';
+	my $module = 'PulseAudio::' . join("", map(ucfirst, split(/_/, $name)));
 
 	has ( $attr, (
-		isa       => 'HashRef'
-		, is      => 'ro'
-		, lazy    => 1
+		isa	  => 'HashRef'
+		, is	  => 'ro'
+		, lazy	  => 1
 		, traits  => ['Hash']
 		, handles  => { sprintf( 'get_%s_by_index', $name ) => 'get' }
 		, default => sub {
@@ -29,7 +27,7 @@ foreach my $name ( qw/card source source_output sink sink_input module client/ )
 			my %db;
 
 			while ( defined $self->get_raw($name) and
-                                (my ($idx, $data) = each %{$self->get_raw($name)}) ) {
+				(my ($idx, $data) = each %{$self->get_raw($name)}) ) {
 				$db{$idx} = $module->new({ index => $idx, dump => $data, server => $self });
 			}
 			\%db;

--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -10,13 +10,14 @@ use PulseAudio::Types qw();
 use autodie;
 use IPC::Run3;
 
-use Data::Dumper;
 our $_command_db;
 
 foreach my $name ( qw/card source source_output sink sink_input module client/ ) {
-	my $attr = $name . 's';
-	my $module = 'PulseAudio::' . ucfirst( lc $name );
-	
+    my $attr = $name . 's';
+    my @parts = split(/_/, $name);
+    foreach (@parts) { $_ = ucfirst; };
+    my $module = 'PulseAudio::' . join('', @parts );
+
 	has ( $attr, (
 		isa       => 'HashRef'
 		, is      => 'ro'
@@ -26,7 +27,9 @@ foreach my $name ( qw/card source source_output sink sink_input module client/ )
 		, default => sub {
 			my $self = shift;
 			my %db;
-			while ( my ($idx, $data) = each %{$self->get_raw($name)} ) {
+
+			while ( defined $self->get_raw($name) and
+                                (my ($idx, $data) = each %{$self->get_raw($name)}) ) {
 				$db{$idx} = $module->new({ index => $idx, dump => $data, server => $self });
 			}
 			\%db;

--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -10,6 +10,7 @@ use PulseAudio::Types qw();
 use autodie;
 use IPC::Run3;
 
+use Data::Dumper;
 our $_command_db;
 
 foreach my $name ( qw/card source source_output sink sink_input module client/ ) {
@@ -232,16 +233,9 @@ has 'info' => (
 		my %db;
 		while ( my $line = $fh->getline ) {
 
-		next if $line =~ /(?:
-			Speakers
-			| Headphones
-			| Internal Microphone
-			| Dock Microphone
-			| Microphone
-			| Speakers
-			| (?-x:HDMI \/ DisplayPort(?-x: \d)?)
-		) \s \(priority
-		/x;
+		        # a little information lost in "ports:" section
+		        next if $line =~ /device\.icon_name/;
+
 			chomp $line;
 			state ( $idx, $cat, $last_key );
 			state @tree_pos;
@@ -278,10 +272,7 @@ has 'info' => (
 					}
 					else {
 						my $x = \%{ $db{$cat}{$idx} };
-						my $level = 0;
-						while ( $level + 1 < @tree_pos ) {
-							$x = \%{ $x->{ $tree_pos[$level++]->{key} } };
-						}
+					        $x = \%{ $x->{ $tree_pos[0]->{key} } };
 						$x->{$k} = $v;
 					}
 					$last_key = $k;

--- a/t/12-parse.t
+++ b/t/12-parse.t
@@ -1,0 +1,6 @@
+use PulseAudio;
+use Test::More tests => 1;
+
+new_ok ( PulseAudio );
+
+1;


### PR DESCRIPTION
This branch is based off parser_changes branch as I needed that one to get PulseAudio working.  Therefore it contains those changes plus fixing how module names are generated (from source_output/input_sink) and more robust handling of when sections are missing from info structure.
