### PR TITLE
Remove given/when, remove smartmatch, make module work with current pactl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,7 @@ requires 'IPC::Run3';
 requires 'MooseX::Types';
 requires 'constant';
 requires 'autodie';
+requires 'List::Util';
 
 requires_external_bin 'pacmd';
 requires_external_bin 'env';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,7 @@ requires 'autodie';
 requires_external_bin 'pacmd';
 requires_external_bin 'env';
 
-repository 'git://github.com/EvanCarroll/perl-pulseaudio.git';
+repository 'git:github.com/EvanCarroll/perl-pulseaudio.git';
 homepage 'https://github.com/EvanCarroll/perl-pulseaudio';
 
 auto_install;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install;
 
 name     'PulseAudio';

--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -285,7 +285,23 @@ has 'info' => (
 						my $x = \%{ $db{$cat}{$idx} };
 						my $level = 0;
 						while ( $level + 1 < @tree_pos ) {
-							$x = \%{ $x->{ $tree_pos[$level++]->{key} } };
+							# If we reach a string but still have values, we have something like
+                            # analog-output-lineout: Line Out (priority 9000, latency offset 0 usec, available: yes)
+                            #          properties:
+                            #                  device.icon_name = "audio-headphones"
+                            # So we remove the name and lose it
+                            # Maybe we should later move it down later
+                            my $h = $tree_pos[$level++]->{key};
+                            if(     $h
+                                and exists $x->{ $h }
+								and ! ref $x->{ $h } ) {
+									my $v = $x->{ $h };
+									#say "Whoops: $v is not a ref, ignoring/fixing";
+									$x->{ $h } = {};
+							};
+							if( $h ) {
+								$x = \%{ $x->{ $h } };
+							};
 						}
 						$x->{$k} = $v;
 					}

--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -16,6 +16,7 @@ our $_command_db;
 foreach my $name ( qw/card source source_output sink sink_input module client/ ) {
 	my $attr = $name . 's';
 	my $module = 'PulseAudio::' . ucfirst( lc $name );
+	$module =~ s/_(\w)/\U$1/;
 
 	has ( $attr, (
 		isa       => 'HashRef'

--- a/lib/PulseAudio/Backend/Utilities.pm
+++ b/lib/PulseAudio/Backend/Utilities.pm
@@ -441,7 +441,8 @@ sub __generate_get_by_method {
 					my $v;
 					$v = $obj->_dump;
 					$v = $v->{$_} for @$loc;
-					next OBJ unless $v ~~ $value;
+					#next OBJ unless $v ~~ $value;
+					next OBJ unless $v eq $value;
 				}
 				return $obj;
 			}

--- a/lib/PulseAudio/Types.pm
+++ b/lib/PulseAudio/Types.pm
@@ -24,12 +24,12 @@ coerce PA_Bool
 	, from Str
 	, via {
 		my $arg;
-		given ( $_ ) {
-			when ( qr/on/i )    { $arg = 1 }
-			when ( qr/off/i )   { $arg = 0 }
-			when ( qr/^[ty]/i ) { $arg = 1 }
-			when ( qr/^[fn]/i ) { $arg = 0 }
-			default { $_ }
+		local $_ =  $_; do { if(0) {}
+			elsif ( /on/i )    { $arg = 1 }
+			elsif ( /off/i )   { $arg = 0 }
+			elsif ( /^[ty]/i ) { $arg = 1 }
+			elsif ( /^[fn]/i ) { $arg = 0 }
+			else  { $_ }
 		};
 		$arg;
 	}
@@ -58,19 +58,19 @@ coerce PA_Name
 coerce PA_Volume
 	, from Str , via {
 		my $ratio;
-		given ( $_ ) {
-			when ( 'MAX' )  { $ratio = FULL_VOLUME }
-			when ( 'HALF' ) { $ratio = 0.50 * FULL_VOLUME }
-			when ( 'MUTE' ) { $ratio = 0 }
-			when ( 'MIN' )  { $ratio = 0 }
-			when ( '' )     {
+		local $_ =  $_; do { if(0) {}
+			elsif ( $_ eq 'MAX' )  { $ratio = FULL_VOLUME }
+			elsif ( $_ eq 'HALF' ) { $ratio = 0.50 * FULL_VOLUME }
+			elsif ( $_ eq 'MUTE' ) { $ratio = 0 }
+			elsif ( $_ eq 'MIN' )  { $ratio = 0 }
+			elsif ( $_ eq '' )     {
 				local $Carp::CarpLevel = 4;
 				Carp::croak 'Invalid PA_Volume (empty string)'
 			}
-			when ( $_ =~ qr/^(\d+)[%]$/ ) {
+			elsif ( $_ =~ qr/^(\d+)[%]$/ ) {
 				$ratio = int($1/100 * FULL_VOLUME );
 			}
-		}
+		};
 		return $ratio;
 	}
 ;

--- a/lib/PulseAudio/Types.pm
+++ b/lib/PulseAudio/Types.pm
@@ -29,7 +29,7 @@ coerce PA_Bool
 			elsif ( /off/i )   { $arg = 0 }
 			elsif ( /^[ty]/i ) { $arg = 1 }
 			elsif ( /^[fn]/i ) { $arg = 0 }
-			else  { $_ }
+			#else  { $_ }
 		};
 		$arg;
 	}


### PR DESCRIPTION
Hi Evan!

Thank you very much for writing this module - it helps me greatly to automate volume control on my PC.

This PR fixes the installation issues I found on a recent version of Perl ( 5.34 ). The changes are:

`.` is not included in `@INC` anymore. This can be fixed by using a more recent version of Module::Install or by explicitly putting `.`  in `@INC` anymore.

The repository URL should be `git:github.com` , not `git://github.com`

`given`/`when` and smartmatch now issue warnings, so I've eliminated them (in a somewhat mechanical way).

The `SinkInput` and `SinkOutput` classes could not be fetched via `->sink_inputs` resp. `->sink_outputs`

If you want finer-grained pull requests, just tell me and I'll split the stuff up!